### PR TITLE
E2ETest: fully-qualify PS script path and skip profile loading

### DIFF
--- a/test/E2ETest/E2ETest.csproj
+++ b/test/E2ETest/E2ETest.csproj
@@ -30,8 +30,9 @@
     <PropertyGroup>
       <_PowerShellExe>pwsh</_PowerShellExe>
       <_PowerShellExe Condition="'$(OS)' == 'Windows_NT'">powershell</_PowerShellExe>
+      <_PlaywrightScript>$([System.IO.Path]::GetFullPath($(OutDir)))playwright.ps1</_PlaywrightScript>
     </PropertyGroup>
-    <Exec Command="$(_PowerShellExe) -NonInteractive -executionpolicy Unrestricted $(OutDir)playwright.ps1 install chromium --with-deps" />
+    <Exec Command="$(_PowerShellExe) -NoProfile -NoLogo -NonInteractive -ExecutionPolicy Unrestricted -Command '$(_PlaywrightScript) install chromium --with-deps'" />
   </Target>
 
 </Project>


### PR DESCRIPTION
Building locally failed for me for two reasons:
* OutDir is a relative path, so PowerShell was unable to find the playwright script in the E2ETest package
* Some commands in my pwsh.exe profile aren't available from Powershell.exe (the profile location is the same)

This PR resolves the absolute directory for the ps1 script and passes the -NoProfile flag to PS