### PR TITLE
Add rate limiting of summary generation

### DIFF
--- a/src/Backend/Api/TicketApi.cs
+++ b/src/Backend/Api/TicketApi.cs
@@ -206,6 +206,6 @@ public static class TicketApi
         dbContext.Tickets.Add(ticket);
         await dbContext.SaveChangesAsync();
 
-        summarizer.UpdateSummary(ticket.TicketId);
+        summarizer.UpdateSummary(ticket.TicketId, enforceRateLimit: true);
     }
 }

--- a/src/Backend/Api/TicketMessagingApi.cs
+++ b/src/Backend/Api/TicketMessagingApi.cs
@@ -41,6 +41,6 @@ public static class TicketMessagingApi
         await dbContext.SaveChangesAsync();
 
         // Runs in the background and notifies when the summary is updated
-        summarizer.UpdateSummary(ticketId);
+        summarizer.UpdateSummary(ticketId, enforceRateLimit: isCustomerMessage);
     }
 }


### PR DESCRIPTION
... when triggered by external (non-staff) user