### PR TITLE
Fix Errors Of Aspire.Hosting.AppHost Version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     <MicrosoftExtensionsVersion>8.6.0</MicrosoftExtensionsVersion>
-    <AspireVersion>8.0.2</AspireVersion>
+    <AspireVersion>8.2.0</AspireVersion>
   </PropertyGroup>
   <ItemGroup>
     <!-- Version together with Aspire -->


### PR DESCRIPTION
There is an error with the version of Aspire.Hosting.AppHost.
![image](https://github.com/user-attachments/assets/87f270de-bc79-42ff-8315-ca40104d3e53)
