### PR TITLE
Update to Aspire 8.2.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     <MicrosoftExtensionsVersion>8.6.0</MicrosoftExtensionsVersion>
-    <AspireVersion>8.0.2</AspireVersion>
+    <AspireVersion>8.2.0</AspireVersion>
   </PropertyGroup>
   <ItemGroup>
     <!-- Version together with Aspire -->
@@ -12,7 +12,7 @@
     <PackageVersion Include="Aspire.Hosting.AppHost" Version="$(AspireVersion)" />
     <PackageVersion Include="Aspire.Hosting.Azure.Storage" Version="$(AspireVersion)" />
     <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="$(AspireVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Qdrant" Version="8.1.0" />
+    <PackageVersion Include="Aspire.Hosting.Qdrant" Version="$(AspireVersion)" />
     <PackageVersion Include="Aspire.Hosting.Redis" Version="$(AspireVersion)" />
     <PackageVersion Include="Aspire.Hosting.Testing" Version="$(AspireVersion)" />
     <PackageVersion Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="$(AspireVersion)" />
@@ -25,7 +25,7 @@
     <!-- Version together with ASP.NET -->
     <PackageVersion Include="Microsoft.AspNetCore.Components.QuickGrid" Version="8.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="8.7.0" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="8.8.0" />
     <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.9.3" />
     <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.DataGrid.EntityFrameworkAdapter" Version="4.9.3" />
     <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="4.9.3" />

--- a/src/AppHost/Program.cs
+++ b/src/AppHost/Program.cs
@@ -38,8 +38,6 @@ if (builder.Environment.IsDevelopment())
         {
             r.WithDataVolume();
         }
-
-        r.WithImageTag("3.30.0"); // Temporary workaround for https://github.com/dotnet/aspire/issues/4646
     });
 }
 


### PR DESCRIPTION
Note this doesn't currently update to use the Python support added in Aspire 8.1 because that requires you to have a venv, which is a further setup step.

Longer term it would be better to change the Python app hosting to run under Docker anyway, so that people don't have to set up or restore venv dependencies.