### PR TITLE
Bumped System.Text.Json back to 9.0.0-rc.2.24473.5

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -51,7 +51,7 @@
     <PackageVersion Include="StatefulReconnection" Version="0.1.0" />
     <PackageVersion Include="Markdown2Pdf" Version="2.2.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.0-release-24352-06" />
-    <PackageVersion Include="System.Text.Json" Version="9.0.0-rtm.24476.4" />
+    <PackageVersion Include="System.Text.Json" Version="9.0.0-rc.2.24473.5" />
     <PackageVersion Include="xunit" Version="2.9.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
     <PackageVersion Include="Duende.IdentityServer" Version="7.0.6" />


### PR DESCRIPTION
The solution currently doesn't build due to a bad package reference for System.Text.Json. This fixes the reference so that it uses v9.0.0-rc.2.24473.5, which is required by Microsoft.Extensions.AI.